### PR TITLE
Fix view-only permissions and improve UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,20 +80,21 @@ Automatic deployment via Vercel on push to main branch.
 
 #### Bug Fixes & Features
 
-- [ ] Add read-only view mode for notes with view permission
-- [ ] Hide delete button on view-only shared notes
-- [ ] Fix note click behavior (first click does nothing, second works)
-- [ ] Fix date/timezone issues (shows 'Yesterday' for just-created items)
-- [ ] Fix folder name editing (broken)
-- [ ] Fix notebook name editing (broken)
+- [x] Add read-only view mode for notes with view permission
+- [x] Hide delete button on view-only shared notes
+- [x] Fix note click behavior (first click does nothing, second works)
+- [x] Fix date/timezone issues (shows 'Yesterday' for just-created items)
+- [x] Fix folder name editing (broken)
+- [x] Fix notebook name editing (broken)
 - [ ] Fix note name editing (if needed)
-- [ ] Fix real-time sync issues (cache invalidation on permissions change)
+- [x] Fix real-time sync issues (cache invalidation on permissions change)
 - [ ] Fix AI enhancement numbered list rendering
 - [ ] Change default share permission to 'can edit' instead of 'can view'
 - [ ] Build out quizzing and typemaxing
 - [ ] Fix user emails showing as UUIDs in share dialog (needs API endpoint)
 - [ ] Create seed script for generating test data
 - [ ] Build out user profiles, maybe teams, maybe friends
+- [ ] Implement master-detail view for notes (instead of modals)
 
 #### Production Readiness (eventually - not today)
 

--- a/app/notebooks/[id]/page.tsx
+++ b/app/notebooks/[id]/page.tsx
@@ -80,6 +80,7 @@ export default function NotebookPage() {
   const [editingNoteTitle, setEditingNoteTitle] = useState('')
   const [isSaving, setIsSaving] = useState(false)
   const [isEditingNotebook, setIsEditingNotebook] = useState(false)
+  const [isLoadingNote, setIsLoadingNote] = useState(false)
 
   // Debounce search input to avoid too many API calls
   const debouncedSearch = useDebounce(search, 300)
@@ -481,19 +482,24 @@ export default function NotebookPage() {
                   onClick={async () => {
                     // For read-only users, just show the note without edit mode
                     const canEdit = !notebook?.shared || notebook?.permission === 'write'
-
-                    const data = await loadNoteView(notebookId, { noteId: note.id })
-                    const fullNote = data?.currentNote
-                    if (fullNote) {
-                      setSelectedNote(fullNote)
-                      if (canEdit) {
-                        setIsEditingNote(true)
-                        setEditingNoteTitle(fullNote.title)
-                        setEditingNoteContent(fullNote.content || '')
-                      } else {
-                        // For read-only users, selectedNote will trigger the read-only modal
-                        setIsEditingNote(false)
+                    
+                    setIsLoadingNote(true)
+                    try {
+                      const data = await loadNoteView(notebookId, { noteId: note.id })
+                      const fullNote = data?.currentNote
+                      if (fullNote) {
+                        setSelectedNote(fullNote)
+                        if (canEdit) {
+                          setIsEditingNote(true)
+                          setEditingNoteTitle(fullNote.title)
+                          setEditingNoteContent(fullNote.content || '')
+                        } else {
+                          // For read-only users, selectedNote will trigger the read-only modal
+                          setIsEditingNote(false)
+                        }
                       }
+                    } finally {
+                      setIsLoadingNote(false)
                     }
                   }}
                   onEdit={
@@ -501,13 +507,18 @@ export default function NotebookPage() {
                     !notebook?.shared || notebook?.permission === 'write'
                       ? async () => {
                           // Same as onClick - open editor directly
-                          const data = await loadNoteView(notebookId, { noteId: note.id })
-                          const fullNote = data?.currentNote
-                          if (fullNote) {
-                            setSelectedNote(fullNote)
-                            setIsEditingNote(true)
-                            setEditingNoteTitle(fullNote.title)
-                            setEditingNoteContent(fullNote.content || '')
+                          setIsLoadingNote(true)
+                          try {
+                            const data = await loadNoteView(notebookId, { noteId: note.id })
+                            const fullNote = data?.currentNote
+                            if (fullNote) {
+                              setSelectedNote(fullNote)
+                              setIsEditingNote(true)
+                              setEditingNoteTitle(fullNote.title)
+                              setEditingNoteContent(fullNote.content || '')
+                            }
+                          } finally {
+                            setIsLoadingNote(false)
                           }
                         }
                       : undefined
@@ -524,6 +535,16 @@ export default function NotebookPage() {
           )}
         </main>
       </div>
+
+      {/* Loading overlay while fetching note */}
+      {isLoadingNote && (
+        <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-lg shadow-xl p-6 flex items-center gap-3">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+            <span className="text-gray-700">Loading note...</span>
+          </div>
+        </div>
+      )}
 
       {/* Read-only Note Viewer Modal */}
       {selectedNote && !isEditingNote && notebook?.shared && notebook?.permission === 'read' && (

--- a/app/notebooks/[id]/page.tsx
+++ b/app/notebooks/[id]/page.tsx
@@ -537,6 +537,12 @@ export default function NotebookPage() {
       </div>
 
       {/* Loading overlay while fetching note */}
+      {/* TODO: Consider implementing master-detail view instead of modals
+          - Left panel: Note list (collapsible)
+          - Right panel: Selected note content (inline view/edit)
+          - Benefits: Better context, smoother navigation, no modal jumps
+          - Mobile: Keep modal approach for space constraints
+      */}
       {isLoadingNote && (
         <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center p-4 z-50">
           <div className="bg-white rounded-lg shadow-xl p-6 flex items-center gap-3">

--- a/app/notebooks/[id]/page.tsx
+++ b/app/notebooks/[id]/page.tsx
@@ -490,9 +490,10 @@ export default function NotebookPage() {
                         setIsEditingNote(true)
                         setEditingNoteTitle(fullNote.title)
                         setEditingNoteContent(fullNote.content || '')
+                      } else {
+                        // For read-only users, selectedNote will trigger the read-only modal
+                        setIsEditingNote(false)
                       }
-                      // For read-only, we could show a read-only view
-                      // but for now just don't open the editor
                     }
                   }}
                   onEdit={


### PR DESCRIPTION
## Summary
- Fixed permission issues for view-only users accessing shared notebooks
- Added loading indicators for better UX
- Updated documentation and marked completed tasks

## Changes
- Fixed note API endpoints to check folder-level permissions (not notebook-level)
- Added read-only modal for users with view permission
- Implemented loading state when fetching notes
- Added TODO for future master-detail view implementation

## Testing
✅ User B can now properly view shared notebooks and notes with read-only permission
✅ Loading indicator provides immediate feedback
✅ Build passes with no errors

🤖 Generated with [Claude Code](https://claude.ai/code)